### PR TITLE
Updated nvm command

### DIFF
--- a/instructions/1 Installation.md
+++ b/instructions/1 Installation.md
@@ -10,7 +10,7 @@ If you need to update Node, please [install `nvm`](https://github.com/creationix
 ```
 curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
 nvm install --lts
-nvm use lts
+nvm use --lts
 ```
 #### IPFS 0.4.15+
 ```


### PR DESCRIPTION
The nvm command to run must have the `--` in front of version identifiers when using LTS.